### PR TITLE
Community build fix: remove redundant use

### DIFF
--- a/src/Either.flix
+++ b/src/Either.flix
@@ -96,7 +96,6 @@ instance Functor[Either[e]] {
 
 mod Either {
 
-    use Either
     use Either.{Left, Right}
 
     ///


### PR DESCRIPTION
This line is a redundant unqualifed `use`, which is made illegal in this PR: https://github.com/flix/flix/pull/6869

The code still compiles and tests pass.