### PR TITLE
fix: Functor instance type parameter

### DIFF
--- a/src/Either.flix
+++ b/src/Either.flix
@@ -30,7 +30,7 @@ instance Hash[Either[a, b]] with Hash[a], Hash[b] {
 }
 
 
-instance Functor[Either[e]] {
+instance Functor[Either[a]] {
     pub def map(f: b -> c \ ef, x: Either[a, b]): Either[a, c] \ ef = Either.mapRight(f, x)
 }
 


### PR DESCRIPTION
This bug is discovered by this PR https://github.com/flix/flix/pull/6499 where we check instance signatures more correctly.