### PR TITLE
feat: remove Sendable

### DIFF
--- a/src/Either.flix
+++ b/src/Either.flix
@@ -17,7 +17,7 @@
 ///
 /// The Either type.
 ///
-pub enum Either[a, b] with Eq, Order, ToString, Sendable {
+pub enum Either[a, b] with Eq, Order, ToString {
     case Left(a)
     case Right(b)
 }


### PR DESCRIPTION
After https://github.com/flix/flix/pull/9556 there is no Sendable trait or `Channel.unsafeSend`. You can just send anything. This PR fixes that